### PR TITLE
Fix Tailwind Purge for Svelte Class Directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,26 +1,25 @@
 {
-  "name": "svelte-app",
-  "version": "1.0.0",
-  "scripts": {
-    "build": "rollup -c",
-    "dev": "rollup -c -w",
-    "start": "sirv public"
-  },
-  "devDependencies": {
-    "autoprefixer": "^10.0.1",
-    "postcss": "^8.0.9",
-    "postcss-load-config": "^2.1.0",
-    "@rollup/plugin-commonjs": "^14.0.0",
-    "@rollup/plugin-node-resolve": "^8.0.0",
-    "rollup": "^2.3.4",
-    "rollup-plugin-livereload": "^2.0.0",
-    "rollup-plugin-svelte": "^6.0.0",
-    "rollup-plugin-terser": "^7.0.0",
-    "svelte": "^3.0.0",
-    "svelte-preprocess": "^4.3.0",
-    "tailwindcss": "^1.8.10"
-  },
-  "dependencies": {
-    "sirv-cli": "^1.0.0"
-  }
+    "name": "svelte-app",
+    "version": "1.0.0",
+    "scripts": {
+        "build": "rollup -c",
+        "dev": "rollup -c -w",
+        "start": "sirv public"
+    },
+    "devDependencies": {
+        "postcss": "^8.0.9",
+        "postcss-load-config": "^2.1.0",
+        "@rollup/plugin-commonjs": "^14.0.0",
+        "@rollup/plugin-node-resolve": "^8.0.0",
+        "rollup": "^2.3.4",
+        "rollup-plugin-livereload": "^2.0.0",
+        "rollup-plugin-svelte": "^6.0.0",
+        "rollup-plugin-terser": "^7.0.0",
+        "svelte": "^3.0.0",
+        "svelte-preprocess": "^4.3.0",
+        "tailwindcss": "^1.8.10"
+    },
+    "dependencies": {
+        "sirv-cli": "^1.0.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "sirv public"
   },
   "devDependencies": {
+    "autoprefixer": "^10.0.1",
     "postcss": "^8.0.9",
     "postcss-load-config": "^2.1.0",
     "@rollup/plugin-commonjs": "^14.0.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-    plugins: [require('tailwindcss'), require('autoprefixer')],
+    plugins: [require('tailwindcss')],
 };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: [require('tailwindcss')],
+    plugins: [require('tailwindcss'), require('autoprefixer')],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,16 +1,21 @@
 module.exports = {
   purge: {
-    mode: 'all',
-    content: ['./**/**/*.html', './**/**/*.svelte'],
+      mode: 'all',
+      content: ['./**/**/*.html', './**/**/*.svelte'],
 
-    options: {
-      whitelistPatterns: [/svelte-/],
-    },
+      options: {
+          whitelistPatterns: [/svelte-/],
+          defaultExtractor: (content) => [...content.matchAll(/(?:class:)*([\w\d-/:%.]+)/gm)].map(([_match, group, ..._rest]) => group),
+      },
   },
 
   theme: {
-    extend: {},
+      extend: {},
   },
   variants: {},
   plugins: [],
+  future: {
+      purgeLayersByDefault: true,
+      removeDeprecatedGapUtilities: true,
+  },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,21 +1,22 @@
 module.exports = {
-  purge: {
-      mode: 'all',
-      content: ['./**/**/*.html', './**/**/*.svelte'],
+    purge: {
+        mode: 'all',
+        content: ['./**/**/*.html', './**/**/*.svelte'],
 
-      options: {
-          whitelistPatterns: [/svelte-/],
-          defaultExtractor: (content) => [...content.matchAll(/(?:class:)*([\w\d-/:%.]+)/gm)].map(([_match, group, ..._rest]) => group),
-      },
-  },
+        options: {
+            whitelistPatterns: [/svelte-/],
+            defaultExtractor: (content) =>
+                [...content.matchAll(/(?:class:)*([\w\d-/:%.]+)/gm)].map(([_match, group, ..._rest]) => group),
+        },
+    },
 
-  theme: {
-      extend: {},
-  },
-  variants: {},
-  plugins: [],
-  future: {
-      purgeLayersByDefault: true,
-      removeDeprecatedGapUtilities: true,
-  },
+    theme: {
+        extend: {},
+    },
+    variants: {},
+    plugins: [],
+    future: {
+        // purgeLayersByDefault: true,
+        // removeDeprecatedGapUtilities: true,
+    },
 };


### PR DESCRIPTION
Hello @sarioglu 

Thank you so much for creating this Svelte+Tailwindcss template. I have been searching around and have found a solution to prevent the tailwind classes used with the [Svelte "class:" directives](https://svelte.dev/tutorial/classes) from being purged during the production build step. Additionally I have added autoprefixer to the postcss plugins to handle vendor prefixes as recommended by the tailwindcss devs.

Summary of the changes in this pull request:

- Added a new defaultextractor to the tailwind config to correctly retain tailwind styles used with Svelte's "class:" directive.
    * Found via [https://github.com/babichjacob/sapper-postcss-template](https://github.com/babichjacob/sapper-postcss-template)
- Added the autoprefixer postcss plugin to include vendor prefixes [as suggested by the tailwindcss devs](https://tailwindcss.com/docs/installation).
- Enabled the upcoming changes flags in the tailwind config [as suggested by the tailwindcss devs](https://tailwindcss.com/docs/upcoming-changes).